### PR TITLE
build: add event type to trigger build for rc image build on rule-executer changing

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - dev
+  repository_dispatch:
+    types: [rule-executer-update]  # Matches event-type from dispatch
   workflow_dispatch:
 
 jobs:
@@ -52,7 +54,6 @@ jobs:
           echo "Fetched version from package.json: $packageVersion"
           rule901Version=$(jq -r '.dependencies["@frmscoe/rule-901"] // .dependencies["@tazama-lf/rule-901"]' rule-executer-902/package.json | sed 's/^[^0-9]*//')
           echo "Fetched rule-901 version from rule-executer package.json: $rule901Version"
-          sed -i 's/npm:@tazama-lf/npm:@frmscoe/' rule-executer-902/package.json
           sed -i "s/rule-901@$rule901Version/rule-902@$packageVersion/" rule-executer-902/package.json
           sed -i 's/901/902/' rule-executer-902/Dockerfile
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
- Add event type to trigger build for rc image build on rule-executer changing
- Remove frmscoe 902 package because the repo moved to tazama-lf

## Why are we doing this?
We want to automate deployments for rule 902 whenever rule-executer changes

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
