### PR TITLE
fix: defensive else-branch for unsupported transaction type, SupportedTransactionMessage signature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    target-branch: 'dev'

--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -23,7 +23,7 @@ jest.mock('@tazama-lf/frms-coe-lib', () => {
 const getMockRequest = (): RuleRequest<Pacs002> => {
   const quote = {
     transaction: JSON.parse(
-      `{"TxTp":"pacs.002.001.12","FIToFIPmtSts":{"GrpHdr":{"MsgId":"6b444365119746c5be7dfb5516ba67c4","CreDtTm":"${new Date(
+      `{"TxTp":"pacs.002.001.12","TenantId":"DEFAULT","FIToFIPmtSts":{"GrpHdr":{"MsgId":"6b444365119746c5be7dfb5516ba67c4","CreDtTm":"${new Date(
         'Mon Dec 03 2021 09:24:48 GMT+0000',
       ).toISOString()}"},"TxInfAndSts":{"OrgnlInstrId":"5ab4fc7355de4ef8a75b78b00a681ed2","OrgnlEndToEndId":"2c516801007642dfb892944dde1cf845","TxSts":"ACCC","ChrgsInf":[{"Amt":{"Amt":307.14,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}}},{"Amt":{"Amt":153.57,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}}},{"Amt":{"Amt":30.71,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp002"}}}}],"AccptncDtTm":"2021-12-03T15:36:16.000Z","InstgAgt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}},"InstdAgt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp002"}}}}}}`,
     ),
@@ -377,5 +377,21 @@ describe('Error conditions', () => {
     } catch (error) {
       expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
     }
+  });
+});
+
+describe('Unsupported transaction type', () => {
+  test('should return early with .err for unrecognised transaction type', async () => {
+    const querySpy = jest.fn();
+    databaseManager._eventHistory.query = querySpy;
+
+    const unsupportedReq = {
+      ...req,
+      transaction: { TxTp: 'unsupported.type.v1', TenantId: 'DEFAULT', someField: 'someValue' } as any,
+    };
+    const res = await handleTransaction(unsupportedReq, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
+    expect(res.subRuleRef).toBe('.err');
+    expect(res.reason).toBe('Unsupported transaction type');
+    expect(querySpy).not.toHaveBeenCalled();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@tazama-lf/rule-902",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-902",
-      "version": "4.0.0-rc.1",
+      "version": "4.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.0.0-rc.1"
+        "@tazama-lf/frms-coe-lib": "8.0.0-rc.2"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -1155,9 +1155,9 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.1.tgz",
-      "integrity": "sha512-zNfBGtukVyc0ClmSzXgeP6eseumdekHfrqa++GsPK8ZUm9Hm3TY8X8LQvGfZVrp23RSz9ebbcruXnAv3no0Q+g==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1175,14 +1175,14 @@
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.4.1",
-        "jest-config": "30.4.1",
+        "jest-config": "30.4.2",
         "jest-haste-map": "30.4.1",
         "jest-message-util": "30.4.1",
         "jest-regex-util": "30.4.0",
         "jest-resolve": "30.4.1",
-        "jest-resolve-dependencies": "30.4.1",
-        "jest-runner": "30.4.1",
-        "jest-runtime": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
         "jest-snapshot": "30.4.1",
         "jest-util": "30.4.1",
         "jest-validate": "30.4.1",
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-rc.1",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.1/9a83e75f3817e5478d7006a92bf4ee0310908d69",
-      "integrity": "sha512-DaC2uI8Kk1Ad7wuIZowI485KypGmEcvI+9zzSiSPAj9fXKGMf4OArqS9ZMhnKHsZIeF0el8N8v8KS+j9BLQbOw==",
+      "version": "8.0.0-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.2/58142df110e5a090fed6f52d3267dc0226859946",
+      "integrity": "sha512-ETed8CuWZHgaYo6Dnr1enaIxJn9pi3ovHGUy3DZo3Q09gX3qifcgYR9icsugJ22NcdGtwD7i4pFhBVfkgYkwWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1792,8 +1792,8 @@
         "pg-format": "^1.0.4",
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
-        "protobufjs": "^7.5.4",
-        "uuid": "^11.1.0"
+        "protobufjs": "^7.5.5",
+        "uuid": "^11.1.1"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -3064,9 +3064,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.28",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
-      "integrity": "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.352",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
     },
@@ -6230,16 +6230,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.1.tgz",
-      "integrity": "sha512-ZXSQlP2bAgIq0XmJ49HNmrgXSoWoHEzciSw3YhPbOA3gVMl3CyLdHjbpV+dbR7ggOVwSEo4cl5OOaYwRrmWqEA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.1",
+        "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.4.1"
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -6272,9 +6272,9 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.1.tgz",
-      "integrity": "sha512-kcCeuPX8Kh6TSujMOIzaAXWvvr41LFlbhLyEYzcc8doXIuGdX+hOxSxbAH7sJItvi1H2ZOU5B3ujD3FLiX5e4g==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6290,7 +6290,7 @@
         "jest-each": "30.4.1",
         "jest-matcher-utils": "30.4.1",
         "jest-message-util": "30.4.1",
-        "jest-runtime": "30.4.1",
+        "jest-runtime": "30.4.2",
         "jest-snapshot": "30.4.1",
         "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
@@ -6304,19 +6304,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.1.tgz",
-      "integrity": "sha512-wh86tmU2ak4aqaVg4Y+OwNys9Plrh4478+o8Zapeo8iz95uwW/WY+A4Yb3pd6C3ilHhY+Ue6V+yDM8G+zUDX+A==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.1",
+        "@jest/core": "30.4.2",
         "@jest/test-result": "30.4.1",
         "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.4.1",
+        "jest-config": "30.4.2",
         "jest-util": "30.4.1",
         "jest-validate": "30.4.1",
         "yargs": "^17.7.2"
@@ -6337,9 +6337,9 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.1.tgz",
-      "integrity": "sha512-AHAI8llsQFfz3oE6/AcBrP7tJdVnqczmBvnXONO8RWRqKefLaxKmkIUq0otc+QTZ/0gxBP7wBLfh6caMmNZcLA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6354,12 +6354,12 @@
         "deepmerge": "^4.3.1",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.1",
+        "jest-circus": "30.4.2",
         "jest-docblock": "30.4.0",
         "jest-environment-node": "30.4.1",
         "jest-regex-util": "30.4.0",
         "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.1",
+        "jest-runner": "30.4.2",
         "jest-util": "30.4.1",
         "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.1.tgz",
-      "integrity": "sha512-MstV4pRIfUBs9kuMHSzYHPMPYHqQGoknfRv6tEEpOX7755aaK4Hk5ICwTtOHyjCc3+hYMoxnKF3ENu3iayEIog==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6607,9 +6607,9 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.1.tgz",
-      "integrity": "sha512-NbStoXGdqMuYF8m7NEQ6FH2gH4eTvcSyz7BINLLuGacdAKtlsDa7PzPSZUtyiBfdMycO2Yeyn3ibfzUl2plRjA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6629,7 +6629,7 @@
         "jest-leak-detector": "30.4.1",
         "jest-message-util": "30.4.1",
         "jest-resolve": "30.4.1",
-        "jest-runtime": "30.4.1",
+        "jest-runtime": "30.4.2",
         "jest-util": "30.4.1",
         "jest-watcher": "30.4.1",
         "jest-worker": "30.4.1",
@@ -6641,9 +6641,9 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.1.tgz",
-      "integrity": "sha512-Ityu3lzs8+it7ABsi7N52Px3Ic1az9w+sBkP/r1xK5MaIq1BdYkYonftpwtX5AtibDSFrKTNEW9KLUXAynXIcA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8219,9 +8219,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8724,9 +8724,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-902",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "description": "Rule 902 is to calculate the number of transactions the creditor has received over a period",
   "main": "index.ts",
   "files": [
@@ -65,6 +65,6 @@
     ]
   },
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.0.0-rc.1"
+    "@tazama-lf/frms-coe-lib": "8.0.0-rc.2"
   }
 }

--- a/src/rule-902.ts
+++ b/src/rule-902.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { DatabaseManagerInstance, LoggerService, ManagerConfig } from '@tazama-lf/frms-coe-lib';
-import type { OutcomeResult, Pacs002, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { isPacs002Transaction } from '@tazama-lf/frms-coe-lib';
+import type { OutcomeResult, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 
 export type RuleExecutorConfig = ManagerConfig &
   Required<Pick<ManagerConfig, 'rawHistory' | 'eventHistory' | 'configuration' | 'localCacheConfig'>>;
@@ -9,7 +10,7 @@ interface CountRow {
   length: number;
 }
 export async function handleTransaction(
-  req: RuleRequest<Pacs002>,
+  req: RuleRequest,
   determineOutcome: (value: number, ruleConfig: RuleConfig, ruleResult: RuleResult) => RuleResult,
   ruleRes: RuleResult,
   loggerService: LoggerService,
@@ -17,6 +18,12 @@ export async function handleTransaction(
   databaseManager: DatabaseManagerInstance<RuleExecutorConfig>,
 ): Promise<RuleResult> {
   const context = `Rule-${ruleConfig.id} handleTransaction()`;
+
+  if (!isPacs002Transaction(req.transaction)) {
+    loggerService.error('Unsupported transaction type', new Error('Unsupported transaction type'), context);
+    return { ...ruleRes, subRuleRef: '.err', reason: 'Unsupported transaction type' };
+  }
+
   const msgId = req.transaction.FIToFIPmtSts.GrpHdr.MsgId;
 
   loggerService.trace('Start - handle transaction', context, msgId);


### PR DESCRIPTION
## Summary

Updates `handleTransaction` to accept `RuleRequest<SupportedTransactionMessage>` (compatible with rule-executer) and adds a defensive guard for unsupported transaction types.

## Changes

- `src/rule-902.ts`:
  - `handleTransaction` parameter changed to `RuleRequest` (default generic resolves to `SupportedTransactionMessage`)
  - `isPacs002Transaction` guard added at function entry - logs error and returns `.err` for unsupported types
  - `isPacs002Transaction` imported from `@tazama-lf/frms-coe-lib` root export
- `__tests__/unit/rule.test.ts`:
  - `TenantId` added to mock transaction fixture (required by `isPacs002Transaction` type guard)
  - New test: "should return early with .err for unrecognised transaction type" with DB-not-queried assertion (11 tests total, 100% coverage)
- `package.json`:
  - `@tazama-lf/frms-coe-lib` bumped to `8.0.0-rc.2`
  - `version` bumped to `4.0.0-rc.2`
- `.github/dependabot.yml`: `target-branch` set to `dev`

## Test results

- 11/11 tests passing
- 100% statements, branches, functions, lines coverage

Closes #268
