### PR TITLE
feat: export RULE_ID, ruleConfigSchema, and validateConfig; remove guard pattern from handleTransaction

### DIFF
--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type DatabaseManagerInstance, LoggerService, CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
-import { type Band, type Pacs002, type RuleConfig, type RuleRequest, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { type Pacs002, type RuleConfig, type RuleRequest, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { CreateStorageManager } from '@tazama-lf/frms-coe-lib/lib/services/dbManager';
 import { handleTransaction } from '../../src';
 import { RuleExecutorConfig } from '../../src/rule-902';
@@ -284,100 +284,6 @@ describe('Error conditions', () => {
     }
   });
 
-  test('Invalid config', async () => {
-    const mockQueryFn = jest.fn();
-
-    const mockBatchesAllFn = jest.fn().mockResolvedValue([['abc']]);
-    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({
-      batches: {
-        all: mockBatchesAllFn,
-      },
-    });
-    jest.spyOn(databaseManager._eventHistory, 'query');
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, parameters: undefined },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - parameters not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, parameters: { '1': 2 } },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - maxQueryRange parameter not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, exitConditions: undefined },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - exitConditions not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, bands: [] },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: {
-            ...ruleConfig.config,
-            bands: undefined as unknown as Band[],
-          },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
-    }
-  });
 });
 
 describe('Unsupported transaction type', () => {

--- a/__tests__/unit/ruleConfig.test.ts
+++ b/__tests__/unit/ruleConfig.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { RULE_ID } from '../../src/rule-902';
+import { ruleConfigSchema, validateConfig } from '../../src/schemas/ruleConfig';
+
+const validConfig = {
+  id: '902@1.0.0',
+  cfg: '1.0.0',
+  tenantId: 'DEFAULT',
+  config: {
+    bands: [{ subRuleRef: '.01', reason: 'Low' }],
+    exitConditions: [{ subRuleRef: '.x00', reason: 'Unsuccessful transaction' }],
+    parameters: { maxQueryRange: 86400000 },
+  },
+};
+
+describe('RULE_ID', () => {
+  it('should equal 902', () => {
+    expect(RULE_ID).toBe('902');
+  });
+});
+
+describe('ruleConfigSchema', () => {
+  it('should accept a valid config', () => {
+    expect(() => ruleConfigSchema.parse(validConfig)).not.toThrow();
+  });
+
+  it('should reject when bands is empty', () => {
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, bands: [] } })).toThrow();
+  });
+
+  it('should reject when bands is absent', () => {
+    const { bands: _b, ...configNoBands } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoBands })).toThrow();
+  });
+
+  it('should reject when exitConditions is empty', () => {
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, exitConditions: [] } })).toThrow();
+  });
+
+  it('should reject when exitConditions is absent', () => {
+    const { exitConditions: _e, ...configNoExit } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoExit })).toThrow();
+  });
+
+  it('should reject when parameters is absent', () => {
+    const { parameters: _p, ...configNoParams } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoParams })).toThrow();
+  });
+
+  it('should reject when maxQueryRange is absent', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: {} } }),
+    ).toThrow();
+  });
+
+  it('should reject when maxQueryRange is not positive', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: 0 } } }),
+    ).toThrow();
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: -1000 } } }),
+    ).toThrow();
+  });
+
+  it('should reject when maxQueryRange is not a number', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: 'daily' } } }),
+    ).toThrow();
+  });
+
+  it('should reject when top-level required fields are missing', () => {
+    const { id: _id, ...noId } = validConfig;
+    expect(() => ruleConfigSchema.parse(noId)).toThrow();
+
+    const { cfg: _cfg, ...noCfg } = validConfig;
+    expect(() => ruleConfigSchema.parse(noCfg)).toThrow();
+
+    const { tenantId: _t, ...noTenant } = validConfig;
+    expect(() => ruleConfigSchema.parse(noTenant)).toThrow();
+  });
+});
+
+describe('validateConfig', () => {
+  it('should not throw for a valid config', () => {
+    expect(() => validateConfig(validConfig as any)).not.toThrow();
+  });
+
+  it('should throw for an invalid config', () => {
+    expect(() => validateConfig({ ...validConfig, config: { ...validConfig.config, bands: [] } } as any)).toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@tazama-lf/rule-902",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-902",
-      "version": "4.0.0-rc.3",
+      "version": "4.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "^8.0.0-rc.3"
+        "@tazama-lf/frms-coe-lib": "8.0.0-rc.5",
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -1774,9 +1775,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.3/875069520a1710fff8de65d3788957c4302da9c0",
-      "integrity": "sha512-EATYohwL80vlTrtwGcY/JKIhSqeeu3iZYa6zDjMt4mjCNkvlF/t3NXCz+FCKhLdfkJIJyHrEbLGss0akAPdf/g==",
+      "version": "8.0.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.5/ca83d3a70118dc6009a7adc3e40c2c8028b3591f",
+      "integrity": "sha512-jrRLZopffgFOaNdy0GR6/dVxIjPiTPC9Z3I01cZFMlJjuIYHaUAfhK57oQuKpz5ti4WudbTuYLT/gPmdILfCeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1793,7 +1794,8 @@
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
         "protobufjs": "^7.5.5",
-        "uuid": "^11.1.1"
+        "uuid": "^11.1.1",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -10465,6 +10467,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-902",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "description": "Rule 902 is to calculate the number of transactions the creditor has received over a period",
   "main": "index.ts",
   "files": [
@@ -65,6 +65,7 @@
     ]
   },
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.0.0-rc.3"
+    "@tazama-lf/frms-coe-lib": "8.0.0-rc.5",
+    "zod": "4.4.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { handleTransaction } from './rule-902';
-export { handleTransaction };
+export { handleTransaction, RULE_ID } from './rule-902';
+export { ruleConfigSchema, validateConfig } from './schemas/ruleConfig';

--- a/src/rule-902.ts
+++ b/src/rule-902.ts
@@ -4,6 +4,8 @@ import type { DatabaseManagerInstance, LoggerService, ManagerConfig } from '@taz
 import { isPacs002Transaction, isStructuredTransaction } from '@tazama-lf/frms-coe-lib';
 import type { OutcomeResult, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 
+export const RULE_ID = '902';
+
 export type RuleExecutorConfig = ManagerConfig &
   Required<Pick<ManagerConfig, 'rawHistory' | 'eventHistory' | 'configuration' | 'localCacheConfig'>>;
 interface CountRow {
@@ -33,20 +35,13 @@ export async function handleTransaction(
 
   loggerService.trace('Start - handle transaction', context, msgId);
 
-  // Throw errors early if something we know we need is not provided - Guard Pattern
-  if (!ruleConfig.config.bands?.length) {
-    throw new Error('Invalid ruleConfig provided - bands not provided or empty');
-  }
-  if (!ruleConfig.config.exitConditions) throw new Error('Invalid ruleConfig provided - exitConditions not provided');
-  if (!ruleConfig.config.parameters) throw new Error('Invalid ruleConfig provided - parameters not provided');
-  if (!ruleConfig.config.parameters.maxQueryRange) throw new Error('Invalid ruleConfig provided - maxQueryRange parameter not provided');
   if (!req.DataCache.dbtrAcctId) throw new Error('Data Cache does not have required dbtrAcctId');
 
   // Step 1: Early exit conditions
 
   loggerService.trace('Step 1 - Early exit conditions', context, msgId);
 
-  const UnsuccessfulTransaction = ruleConfig.config.exitConditions.find((b: OutcomeResult) => b.subRuleRef === '.x00');
+  const UnsuccessfulTransaction = ruleConfig.config.exitConditions!.find((b: OutcomeResult) => b.subRuleRef === '.x00');
 
   if (req.transaction.FIToFIPmtSts.TxInfAndSts.TxSts !== 'ACCC') {
     if (UnsuccessfulTransaction === undefined) throw new Error('Unsuccessful transaction and no exit condition in ruleConfig');
@@ -64,7 +59,7 @@ export async function handleTransaction(
 
   const currentPacs002TimeFrame = req.transaction.FIToFIPmtSts.GrpHdr.CreDtTm;
   const creditorAccountId = req.DataCache.cdtrAcctId;
-  const maxQueryRange: number = ruleConfig.config.parameters.maxQueryRange as number;
+  const maxQueryRange: number = ruleConfig.config.parameters!.maxQueryRange as number;
   const tenantId = req.transaction.TenantId;
 
   const values = [creditorAccountId, currentPacs002TimeFrame, maxQueryRange, tenantId];

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { baseConfigSchema, baseRuleConfigSchema, BandSchema, OutcomeResultSchema } from '@tazama-lf/frms-coe-lib';
+import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { z } from 'zod';
+
+const rule902ConfigSchema = baseConfigSchema.extend({
+  bands: z.array(BandSchema).min(1),
+  exitConditions: z.array(OutcomeResultSchema).min(1),
+  parameters: z.object({
+    maxQueryRange: z.number().positive(),
+  }),
+});
+
+export const ruleConfigSchema = baseRuleConfigSchema.extend({ config: rule902ConfigSchema });
+
+export const validateConfig = (config: RuleConfig): void => {
+  ruleConfigSchema.parse(config);
+};


### PR DESCRIPTION
## Summary

Implements tazama-lf/rule-902#81.

Adds `RULE_ID`, `ruleConfigSchema`, and `validateConfig` exports to support identity verification and portable config validation across the rule-executer and admin tooling. Removes the hand-written Guard Pattern from `handleTransaction` - config validation now happens once at startup via the `onConfigLoaded` hook.

## Changes

### `src/rule-902.ts`
- Added `export const RULE_ID = '902';` at the top of the file
- Removed the Guard Pattern block (`bands`, `exitConditions`, `parameters`, `maxQueryRange` checks)
- Added `!` non-null assertions on `exitConditions` and `parameters` references (validated at startup)
- Retained `DataCache.dbtrAcctId` check (request data, not rule config)

### `src/schemas/ruleConfig.ts` (new)
- `rule902ConfigSchema` - extends `baseConfigSchema` with `bands` (non-empty), `exitConditions` (non-empty), `parameters.maxQueryRange` (positive number)
- `ruleConfigSchema` - extends `baseRuleConfigSchema` with the rule-specific config schema
- `validateConfig` - thin wrapper around `ruleConfigSchema.parse()`

### `src/index.ts`
- Re-exports `RULE_ID` from `./rule-902`
- Re-exports `ruleConfigSchema` and `validateConfig` from `./schemas/ruleConfig`

### `__tests__/unit/ruleConfig.test.ts` (new)
- 12 tests: RULE_ID value, valid config, each required field absent/empty/invalid, top-level fields missing, validateConfig pass/fail

### `__tests__/unit/rule.test.ts`
- Removed `Band` import (no longer needed)
- Removed "Invalid config" test block (guard pattern tests no longer applicable)

### `package.json`
- Bumped version to `4.0.0-rc.4`
- Updated `@tazama-lf/frms-coe-lib` from `8.0.0-rc.3` to `8.0.0-rc.5` (exact, no caret)
- Added `zod` `4.4.3` as a runtime dependency (exact, no caret)

## Test results

24 tests pass across 2 suites. `@tazama-lf/rule-902@4.0.0-rc.4` published under the `rc` dist-tag.

## Related

- Closes tazama-lf/rule-902#81
- tazama-lf/frms-coe-lib#383 (base schemas - prerequisite)
- tazama-lf/rule-executer#406 (validateConfig wiring)
- tazama-lf/rule-executer#407 (RULE_ID identity verification)