### PR TITLE
fix: enforce .x00 exit condition in schema, remove redundant runtime guard

### DIFF
--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -219,22 +219,6 @@ describe('Exit conditions', () => {
 });
 
 describe('Error conditions', () => {
-  test('Unsuccessful transaction and no exit condition', async () => {
-    const mockQueryFn = jest.fn();
-    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 4 }]});
-    jest.spyOn(databaseManager._eventHistory, 'query');
-    const objClone = (req: Object) => JSON.parse(JSON.stringify(req));
-    const newReq: RuleRequest<Pacs002> = objClone(req);
-    newReq.transaction.FIToFIPmtSts.TxInfAndSts.TxSts = 'something else';
-    const newConfig: RuleConfig = objClone(ruleConfig);
-    newConfig.config.exitConditions![0].subRuleRef = 'something';
-    try {
-      await handleTransaction(newReq, determineOutcome, ruleRes, loggerService, newConfig, databaseManager);
-    } catch (error) {
-      expect((error as Error).message).toBe('Unsuccessful transaction and no exit condition in ruleConfig');
-    }
-  });
-
   test('No transactions', async () => {
     const mockQueryFn = jest.fn();
     databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 0 }]});

--- a/__tests__/unit/ruleConfig.test.ts
+++ b/__tests__/unit/ruleConfig.test.ts
@@ -38,6 +38,15 @@ describe('ruleConfigSchema', () => {
     expect(() => ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, exitConditions: [] } })).toThrow();
   });
 
+  it("should reject when exitConditions has no '.x00' entry", () => {
+    expect(() =>
+      ruleConfigSchema.parse({
+        ...validConfig,
+        config: { ...validConfig.config, exitConditions: [{ subRuleRef: '.01', reason: 'Some other condition' }] },
+      }),
+    ).toThrow("exitConditions must include a '.x00' entry");
+  });
+
   it('should reject when exitConditions is absent', () => {
     const { exitConditions: _e, ...configNoExit } = validConfig.config;
     expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoExit })).toThrow();

--- a/__tests__/unit/ruleConfig.test.ts
+++ b/__tests__/unit/ruleConfig.test.ts
@@ -44,7 +44,7 @@ describe('ruleConfigSchema', () => {
         ...validConfig,
         config: { ...validConfig.config, exitConditions: [{ subRuleRef: '.01', reason: 'Some other condition' }] },
       }),
-    ).toThrow("exitConditions must include a '.x00' entry");
+    ).toThrow(`exitConditions must include a '.x00' entry`);
   });
 
   it('should reject when exitConditions is absent', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-902",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "Rule 902 is to calculate the number of transactions the creditor has received over a period",
   "main": "index.ts",
   "files": [

--- a/src/rule-902.ts
+++ b/src/rule-902.ts
@@ -41,11 +41,9 @@ export async function handleTransaction(
 
   loggerService.trace('Step 1 - Early exit conditions', context, msgId);
 
-  const UnsuccessfulTransaction = ruleConfig.config.exitConditions!.find((b: OutcomeResult) => b.subRuleRef === '.x00');
+  const UnsuccessfulTransaction = ruleConfig.config.exitConditions!.find((b: OutcomeResult) => b.subRuleRef === '.x00')!;
 
   if (req.transaction.FIToFIPmtSts.TxInfAndSts.TxSts !== 'ACCC') {
-    if (UnsuccessfulTransaction === undefined) throw new Error('Unsuccessful transaction and no exit condition in ruleConfig');
-
     return {
       ...ruleRes,
       reason: UnsuccessfulTransaction.reason,

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -6,7 +6,10 @@ import { z } from 'zod';
 
 const rule902ConfigSchema = baseConfigSchema.extend({
   bands: z.array(BandSchema).min(1),
-  exitConditions: z.array(OutcomeResultSchema).min(1),
+  exitConditions: z
+    .array(OutcomeResultSchema)
+    .min(1)
+    .refine((conditions) => conditions.some((c) => c.subRuleRef === '.x00'), { message: "exitConditions must include a '.x00' entry" }),
   parameters: z.object({
     maxQueryRange: z.number().positive(),
   }),


### PR DESCRIPTION
## Summary

The `ruleConfigSchema` previously validated that `exitConditions` was non-empty (`.min(1)`), but did not verify that a `.x00` entry was present. This meant a config could pass schema validation while missing the specific exit condition that `handleTransaction` relies on, leaving a runtime `undefined` dereference possible despite the non-null assertion.

### Changes

- **`src/schemas/ruleConfig.ts`** - Added `.refine()` to `exitConditions` to explicitly require a `.x00` entry:
  ```typescript
  exitConditions: z.array(OutcomeResultSchema).min(1).refine(
    (conditions) => conditions.some((c) => c.subRuleRef === '.x00'),
    { message: "exitConditions must include a '.x00' entry" },
  ),
  ```

- **`src/rule-902.ts`** - Added `!` non-null assertion to the `.find()` result and removed the redundant `undefined` throw guard (now guaranteed by schema validation at config load time)

- **`__tests__/unit/rule.test.ts`** - Removed "Unsuccessful transaction and no exit condition" test (tested the now-deleted runtime guard)

- **`__tests__/unit/ruleConfig.test.ts`** - Added test asserting the schema rejects configs where `exitConditions` contains entries but none with `subRuleRef === '.x00'`