### PR TITLE
fix: count only transactions at or before the incoming transaction time

### DIFF
--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -303,3 +303,22 @@ describe('Unsupported transaction type', () => {
     expect(querySpy).not.toHaveBeenCalled();
   });
 });
+
+describe('Query construction', () => {
+  test('should bound the count to transactions at or before the incoming transaction timestamp', async () => {
+    const mockQueryFn = jest.fn().mockResolvedValue({ rows: [{ length: 1 }] });
+    databaseManager._eventHistory.query = mockQueryFn;
+
+    await handleTransaction(req, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
+
+    expect(mockQueryFn).toHaveBeenCalledTimes(1);
+    const [queryString, values] = mockQueryFn.mock.calls[0];
+
+    // The upper bound prevents counting transactions newer than the incoming transaction
+    expect(queryString).toContain('tr."credttm"::timestamptz <= $2::timestamptz');
+    // The lower bound keeps the lookback window
+    expect(queryString).toContain(`($2::timestamptz - tr."credttm"::timestamptz) <= $3 * interval '1 millisecond'`);
+    expect(values[1]).toBe(req.transaction.FIToFIPmtSts.GrpHdr.CreDtTm);
+    expect(values[2]).toBe(ruleConfig.config.parameters!.maxQueryRange);
+  });
+});

--- a/src/rule-902.ts
+++ b/src/rule-902.ts
@@ -66,6 +66,7 @@ export async function handleTransaction(
 FROM transaction tr
 WHERE tr.source = $1
 AND tr."txtp" = 'pacs.002.001.12'
+AND tr."credttm"::timestamptz <= $2::timestamptz
 AND ($2::timestamptz - tr."credttm"::timestamptz) <= $3 * interval '1 millisecond'
 AND tr.tenantId = $4;`;
 


### PR DESCRIPTION
## Summary

Fixes #101.

Rule 902 counts the creditor's transactions within a lookback window. The count query bounded transaction **age** only:

```sql
AND ($2::timestamptz - tr."credttm"::timestamptz) <= $3 * interval '1 millisecond'
```

For any row whose `credttm` is **after** the incoming pacs.002 timestamp (`$2`), the difference `$2 - credttm` is negative, which trivially satisfies `<= maxQueryRange`. As a result, transactions dated after the incoming transaction were always counted.

## Root cause

The upper bound `AND pacs002.CreDtTm <= ${currentPacs002TimeFrame}` present in the original AQL implementation was dropped during the Postgres refactor (commit `da56367`, "refactor: allow the rule to use postgres db"). Only the age (lower) bound survived.

## Fix

Restore the upper bound so the rule counts only transactions occurring at or before the incoming transaction:

```sql
WHERE tr.source = $1
AND tr."txtp" = 'pacs.002.001.12'
AND tr."credttm"::timestamptz <= $2::timestamptz          -- restored upper bound
AND ($2::timestamptz - tr."credttm"::timestamptz) <= $3 * interval '1 millisecond'
AND tr.tenantId = $4;
```

## Tests

- Existing unit tests unchanged and passing (DB query is mocked).
- Added a `Query construction` test asserting the generated query includes the upper-bound predicate as well as the lookback-window predicate.

## Notes

- Companion fix: tazama-lf/rule-901#300 (identical defect on the debtor side).
- Issue will be linked via the Development sidebar; closing keywords do not auto-close on a `dev`-targeted PR.
