### PR TITLE
ci: align main workflow files with dev ahead of release

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -1,16 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# Caller workflow: builds and pushes the RC Docker image for this rule processor.
+#
+# Triggers:
+#   - Automatically on push to the source branch (dev) for rc package versions.
+#   - Manually via workflow_dispatch.
+#
 # This file is managed centrally - do not edit manually.
 # To change build behaviour, update the reusable workflow in tazama-lf/workflows.
+
+name: Package RC rule image
+
 on:
   push:
-    branches: [dev]
-  repository_dispatch:
-    types: [rule-executer-update]
+    branches:
+      - dev
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
 jobs:
-  build:
-    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev
+  package-rule-rc:
+    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@v1
     with:
-      rule_number: "902"
-      rule_org: "tazama-lf"
+      rule_number: ${{ vars.RULE_NUMBER || '902' }}
+      rule_org: ${{ vars.RULE_ORG || 'frmscoe' }}
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      rule_executer_repo: ${{ vars.RULE_EXECUTER_REPO || 'tazama-lf/rule-executer' }}
+      rule_executer_branch: ${{ vars.RULE_EXECUTER_BRANCH || 'dev' }}
+      docker_image_namespace: ${{ vars.DOCKER_IMAGE_NAMESPACE || 'tazamaorg' }}
     secrets: inherit

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -1,14 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# Caller workflow: builds and pushes the stable Docker image for this rule processor.
+#
+# Triggers:
+#   - Automatically on push to the target branch (main) after stable release merge.
+#   - Manually via workflow_dispatch.
+#
+# Produces a versioned Docker tag and the :latest pointer for this rule.
+#
 # This file is managed centrally - do not edit manually.
 # To change build behaviour, update the reusable workflow in tazama-lf/workflows.
+
+name: Package stable rule image
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
 jobs:
-  build:
-    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@main
+  package-rule:
+    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@v1
     with:
-      rule_number: "902"
-      rule_org: "tazama-lf"
+      rule_number: ${{ vars.RULE_NUMBER || '902' }}
+      rule_org: ${{ vars.RULE_ORG || 'frmscoe' }}
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      rule_executer_repo: ${{ vars.RULE_EXECUTER_REPO || 'tazama-lf/rule-executer' }}
+      rule_executer_branch: ${{ vars.RULE_EXECUTER_BRANCH || 'main' }}
+      docker_image_namespace: ${{ vars.DOCKER_IMAGE_NAMESPACE || 'tazamaorg' }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   packages: write
   contents: read
+  pull-requests: read
 
 jobs:
   publish:


### PR DESCRIPTION
Automated pre-release alignment. Overwrites the files that would otherwise conflict in the dev -> main release merge with their current `dev` blobs (dev is canonical; main is expendable for the release). Only conflict-intersection files are touched - no version bump or application code is promoted here; the dev -> main release PR remains the path that carries the actual payload.